### PR TITLE
Fix computing effective branch name from `GITHUB_REF` on GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
         - os: macos-latest
           path: ~/Library/Caches/pip
+        - os: windows-latest
+          path: ~\AppData\Local\pip\Cache
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,73 @@
+name: Tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        include:
+        - os: ubuntu-latest
+          path: ~/.cache/pip
+        - os: macos-latest
+          path: ~/Library/Caches/pip
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    defaults:
+      run:
+        shell: bash
+
+    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ matrix.path }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
+
+    - name: Run tests
+      run: |
+        pip install --requirement=requirements-test.txt
+        pytest
+
+    - name: Upload test results to wacklig
+      if: always()
+      continue-on-error: true
+      env:
+        WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN \
+          && echo "Upload to wacklig succeeded" \
+          || errcode=$?; echo "Upload to wacklig failed"; exit $errcode
+
+#    - name: Generate coverage report
+#      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+#      run: |
+#        coverage xml
+#
+#    - name: Upload coverage to Codecov
+#      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+#      uses: codecov/codecov-action@v2
+#      with:
+#        files: ./coverage.xml
+#        flags: unittests
+#        env_vars: OS,PYTHON
+#        name: codecov-umbrella
+#        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.idea
+/.venv*
+/test-results
+/.coverage
+__pycache__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 
 - Tests: Add test harness
 - Fix finding test report files recursively
+- Tests: Add test for `main` function
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Tests: Add test for `main` function
 - Tests: Run test harness on GHA
 - Tests: Add Windows to test matrix on CI/GHA
+- Tests: Fix tests on Windows
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## in progress
 
+- Tests: Add test harness
+
 
 ## 0.3.0 (2021-07-01)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 - Tests: Run test harness on GHA
 - Tests: Add Windows to test matrix on CI/GHA
 - Tests: Fix tests on Windows
+- Add compatibility with Windows regarding exclusive write-lock
+  at `NamedTemporaryFile` vs. `tarfile.open`
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fix finding test report files recursively
 - Tests: Add test for `main` function
 - Tests: Run test harness on GHA
+- Tests: Add Windows to test matrix on CI/GHA
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,27 @@
+# wacklig-uploader changelog
+
+
+## in progress
+
+
+## 0.3.0 (2021-07-01)
+
+- Make glob path to pick up test results less restrictive
+- Detect GitHub Action environment
+
+
+## 0.2.0 (2021-02-19)
+
+- Don't print args/ci_info but server result instead
+
+
+## 0.1.0 (2021-01-28)
+
+- Adapt upload URI
+- Add token and local/git ci info
+- Add license and minimal readme
+
+
+## 0.0.0 (2021-01-07)
+
+- Initial commit

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Tests: Add test harness
 - Fix finding test report files recursively
 - Tests: Add test for `main` function
+- Tests: Run test harness on GHA
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 - Tests: Fix tests on Windows
 - Add compatibility with Windows regarding exclusive write-lock
   at `NamedTemporaryFile` vs. `tarfile.open`
+- Fix computing effective branch name from `GITHUB_REF`, when
+  running directly on a branch (no PR) on GHA and the branch
+  contained slashes
 
 
 ## 0.3.0 (2021-07-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## in progress
 
 - Tests: Add test harness
+- Fix finding test report files recursively
 
 
 ## 0.3.0 (2021-07-01)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # wacklig-uploader
 
-A python script to upload test results to [wacklig][1].
+## About
+
+A Python script to upload test results to [wacklig].
 
 
+## Tests
 
-[1]: https://wacklig.pipifein.dev/
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --requirement=requirements-test.txt
+
+# Run all tests.
+pytest
+
+# Run specific tests.
+pytest -k test_upload_files
+```
+
+[wacklig]: https://wacklig.pipifein.dev/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.isort]
+profile = "black"
+extend_skip = "wacklig.py"
+
+
+[tool.black]
+line_length = 120
+extend_exclude = "wacklig.py"
+
+
+[tool.pytest.ini_options]
+addopts = """
+    -vvv
+    --cov --cov-report=term-missing
+    --junit-xml=test-results/test/junit.xml
+"""
+
+junit_suite_name = "wacklig_uploader"
+
+# TODO: Write captured log messages to JUnit report: one of no|log|system-out|system-err|out-err|all
+# junit_logging =
+
+# TODO: Emit XML for schema: one of legacy|xunit1|xunit2
+# junit_family =

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest>=6,<7
+pytest-cov>=3,<4
+pyfakefs>=4,<5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest>=6,<7
+pytest-mock>=3,<4
 pytest-cov>=3,<4
 pyfakefs>=4,<5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest>=6,<7
 pytest-mock>=3,<4
 pytest-cov>=3,<4
 pyfakefs>=4,<5
+mocket>=3,<4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Make sure that the application source directory (this directory's parent) is
+# on sys.path.
+here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, here)

--- a/tests/junit-example.xml
+++ b/tests/junit-example.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="wacklig_uploader" errors="0" failures="1" skipped="0" tests="9" time="0.118" timestamp="2021-12-18T03:51:53.894578" hostname="sink.local">
+    <testcase classname="tests.test_uploader" name="test_search_env_found" time="0.001"/>
+    <testcase classname="tests.test_uploader" name="test_search_env_notfound" time="0.000"/>
+    <testcase classname="tests.test_uploader" name="test_jenkins_env" time="0.002"/>
+    <testcase classname="tests.test_uploader" name="test_github_action_env" time="0.002"/>
+    <testcase classname="tests.test_uploader" name="test_get_ci_info_jenkins" time="0.002"/>
+    <testcase classname="tests.test_uploader" name="test_get_ci_info_github" time="0.001"/>
+    <testcase classname="tests.test_uploader" name="test_get_ci_info_local" time="0.001"/>
+    <testcase classname="tests.test_uploader" name="test_upload_files_empty" time="0.000"/>
+    <testcase classname="tests.test_uploader" name="test_upload_files_foo" time="0.003">
+      <failure message="SystemExit: No test files found">tmp_path = PosixPath('/private/var/folders/06/w9pzygdj7vx53n_0l9q_lhph0000gn/T/pytest-of-amo/pytest-5/test_upload_files_foo0')
+
+    def test_upload_files_foo(tmp_path):
+&gt;       upload_files(token=None, server=None, ci_info=None, files=None)
+
+tests/test_uploader.py:95: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+token = None, server = None, ci_info = None, files = None
+
+    def upload_files(token, server, ci_info, files):
+        if not files:
+&gt;           raise SystemExit('No test files found')
+E           SystemExit: No test files found
+
+wacklig.py:76: SystemExit</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,7 +2,9 @@ import os
 from unittest import mock
 from unittest.mock import Mock
 
-from wacklig import get_ci_info, github_action_env, jenkins_env, search_env
+import pytest
+
+from wacklig import get_ci_info, github_action_env, search_env
 
 
 @mock.patch.dict(os.environ, {"CI_FOOBAR": "bazqux"})
@@ -17,7 +19,7 @@ def test_search_env_notfound():
 
 
 @mock.patch.dict(os.environ, {"JENKINS_URL": "https://jenkins.example.org/job/3f786850e3"})
-@mock.patch.dict(os.environ, {"ghprbSourceBranch": "testdrive"})
+@mock.patch.dict(os.environ, {"ghprbSourceBranch": "author/feature-branch-1"})
 @mock.patch.dict(os.environ, {"GIT_COMMIT": "3f786850e387550fdab836ed7e6dc881de23001b"})
 @mock.patch.dict(os.environ, {"ghprbPullId": "111"})
 @mock.patch.dict(os.environ, {"BUILD_NUMBER": "42"})
@@ -25,7 +27,7 @@ def test_get_ci_info_jenkins():
     data = get_ci_info()
     assert data == {
         "service": "jenkins",
-        "branch": "testdrive",
+        "branch": "author/feature-branch-1",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
         "pr": "111",
         "build": "42",
@@ -35,7 +37,7 @@ def test_get_ci_info_jenkins():
 @mock.patch.dict(os.environ, {"GITHUB_ACTION": "true"})
 @mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
 @mock.patch.dict(os.environ, {"GITHUB_REF": "refs/pull/111/merge"})
-@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": "feature-branch-1"})
+@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": "author/feature-branch-1"})
 @mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
 def test_get_ci_info_github_with_pr():
     data = get_ci_info()
@@ -43,14 +45,14 @@ def test_get_ci_info_github_with_pr():
         "service": "github-actions",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
         "build": "42",
-        "branch": "feature-branch-1",
+        "branch": "author/feature-branch-1",
         "pr": "111",
     }
 
 
 @mock.patch.dict(os.environ, {"GITHUB_ACTION": "true"})
 @mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
-@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/feature-branch-1"})
+@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/author/feature-branch-1"})
 @mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": ""})
 @mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
 def test_get_ci_info_github_with_branch():
@@ -59,20 +61,31 @@ def test_get_ci_info_github_with_branch():
         "service": "github-actions",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
         "build": "42",
-        "branch": "feature-branch-1",
+        "branch": "author/feature-branch-1",
     }
+
+
+@pytest.mark.parametrize("branch", ["feature-branch-1", "author/feature-branch-1", "realm/author/feature-branch-1"])
+def test_github_parse_branch_from_ref(mocker, branch):
+    """
+    Validate that the machinery correctly strips off `refs/heads/` for
+    computing the effective branch name.
+    """
+    mocker.patch.dict(os.environ, {"GITHUB_REF": f"refs/heads/{branch}"})
+    ci_info = github_action_env()
+    assert ci_info["branch"] == branch
 
 
 @mock.patch.dict(os.environ, {"JENKINS_URL": ""})
 @mock.patch.dict(os.environ, {"GITHUB_ACTION": ""})
 @mock.patch(
     "wacklig.check_output",
-    Mock(side_effect=["testdrive", "3f786850e387550fdab836ed7e6dc881de23001b"]),
+    Mock(side_effect=["author/feature-branch-1", "3f786850e387550fdab836ed7e6dc881de23001b"]),
 )
 def test_get_ci_info_local():
     data = get_ci_info()
     assert data == {
         "service": "local",
-        "branch": "testdrive",
+        "branch": "author/feature-branch-1",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
     }

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,116 @@
+import os
+from unittest import mock
+from unittest.mock import Mock
+
+from wacklig import get_ci_info, github_action_env, jenkins_env, search_env
+
+
+@mock.patch.dict(os.environ, {"CI_FOOBAR": "bazqux"})
+def test_search_env_found():
+    value = search_env("CI_FOOBAR")
+    assert value == "bazqux"
+
+
+def test_search_env_notfound():
+    value = search_env("CI_FOOBAR")
+    assert value is None
+
+
+@mock.patch.dict(os.environ, {"ghprbSourceBranch": "testdrive"})
+@mock.patch.dict(os.environ, {"GIT_COMMIT": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"ghprbPullId": "111"})
+@mock.patch.dict(os.environ, {"BUILD_NUMBER": "42"})
+def test_jenkins_env():
+    data = jenkins_env()
+    assert data == {
+        "service": "jenkins",
+        "branch": "testdrive",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "pr": "111",
+        "build": "42",
+    }
+
+
+@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
+def test_github_action_env():
+    data = github_action_env()
+    assert data == {
+        "service": "github-actions",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "build": "42",
+    }
+
+
+@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
+@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/feature-branch-1"})
+def test_github_action_env_with_branch():
+    data = github_action_env()
+    assert data == {
+        "service": "github-actions",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "build": "42",
+        "branch": "feature-branch-1",
+    }
+
+
+@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
+@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/pull/111/merge"})
+@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": "feature-branch-1"})
+def test_github_action_env_with_pr():
+    data = github_action_env()
+    assert data == {
+        "service": "github-actions",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "build": "42",
+        "branch": "feature-branch-1",
+        "pr": "111",
+    }
+
+
+@mock.patch.dict(
+    os.environ,
+    {"JENKINS_URL": "https://jenkins.example.org/job/3f786850e387550fdab836ed7e6dc881de23001b"},
+)
+@mock.patch.dict(os.environ, {"ghprbSourceBranch": "testdrive"})
+@mock.patch.dict(os.environ, {"GIT_COMMIT": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"ghprbPullId": "9999"})
+@mock.patch.dict(os.environ, {"BUILD_NUMBER": "42"})
+def test_get_ci_info_jenkins():
+    data = get_ci_info()
+    assert data == {
+        "service": "jenkins",
+        "branch": "testdrive",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "pr": "9999",
+        "build": "42",
+    }
+
+
+@mock.patch.dict(os.environ, {"GITHUB_ACTION": "true"})
+@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
+def test_get_ci_info_github():
+    data = get_ci_info()
+    assert data == {
+        "service": "github-actions",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "build": "42",
+    }
+
+
+@mock.patch.dict(os.environ, {"JENKINS_URL": ""})
+@mock.patch.dict(os.environ, {"GITHUB_ACTION": ""})
+@mock.patch(
+    "wacklig.check_output",
+    Mock(side_effect=["testdrive", "3f786850e387550fdab836ed7e6dc881de23001b"]),
+)
+def test_get_ci_info_local():
+    data = get_ci_info()
+    assert data == {
+        "service": "local",
+        "branch": "testdrive",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+    }

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -16,67 +16,10 @@ def test_search_env_notfound():
     assert value is None
 
 
+@mock.patch.dict(os.environ, {"JENKINS_URL": "https://jenkins.example.org/job/3f786850e3"})
 @mock.patch.dict(os.environ, {"ghprbSourceBranch": "testdrive"})
 @mock.patch.dict(os.environ, {"GIT_COMMIT": "3f786850e387550fdab836ed7e6dc881de23001b"})
 @mock.patch.dict(os.environ, {"ghprbPullId": "111"})
-@mock.patch.dict(os.environ, {"BUILD_NUMBER": "42"})
-def test_jenkins_env():
-    data = jenkins_env()
-    assert data == {
-        "service": "jenkins",
-        "branch": "testdrive",
-        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
-        "pr": "111",
-        "build": "42",
-    }
-
-
-@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
-@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
-def test_github_action_env():
-    data = github_action_env()
-    assert data == {
-        "service": "github-actions",
-        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
-        "build": "42",
-    }
-
-
-@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
-@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
-@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/feature-branch-1"})
-def test_github_action_env_with_branch():
-    data = github_action_env()
-    assert data == {
-        "service": "github-actions",
-        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
-        "build": "42",
-        "branch": "feature-branch-1",
-    }
-
-
-@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
-@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
-@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/pull/111/merge"})
-@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": "feature-branch-1"})
-def test_github_action_env_with_pr():
-    data = github_action_env()
-    assert data == {
-        "service": "github-actions",
-        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
-        "build": "42",
-        "branch": "feature-branch-1",
-        "pr": "111",
-    }
-
-
-@mock.patch.dict(
-    os.environ,
-    {"JENKINS_URL": "https://jenkins.example.org/job/3f786850e387550fdab836ed7e6dc881de23001b"},
-)
-@mock.patch.dict(os.environ, {"ghprbSourceBranch": "testdrive"})
-@mock.patch.dict(os.environ, {"GIT_COMMIT": "3f786850e387550fdab836ed7e6dc881de23001b"})
-@mock.patch.dict(os.environ, {"ghprbPullId": "9999"})
 @mock.patch.dict(os.environ, {"BUILD_NUMBER": "42"})
 def test_get_ci_info_jenkins():
     data = get_ci_info()
@@ -84,20 +27,39 @@ def test_get_ci_info_jenkins():
         "service": "jenkins",
         "branch": "testdrive",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
-        "pr": "9999",
+        "pr": "111",
         "build": "42",
     }
 
 
 @mock.patch.dict(os.environ, {"GITHUB_ACTION": "true"})
 @mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/pull/111/merge"})
+@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": "feature-branch-1"})
 @mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
-def test_get_ci_info_github():
+def test_get_ci_info_github_with_pr():
     data = get_ci_info()
     assert data == {
         "service": "github-actions",
         "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
         "build": "42",
+        "branch": "feature-branch-1",
+        "pr": "111",
+    }
+
+
+@mock.patch.dict(os.environ, {"GITHUB_ACTION": "true"})
+@mock.patch.dict(os.environ, {"GITHUB_SHA": "3f786850e387550fdab836ed7e6dc881de23001b"})
+@mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/feature-branch-1"})
+@mock.patch.dict(os.environ, {"GITHUB_HEAD_REF": ""})
+@mock.patch.dict(os.environ, {"GITHUB_RUN_ID": "42"})
+def test_get_ci_info_github_with_branch():
+    data = get_ci_info()
+    assert data == {
+        "service": "github-actions",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+        "build": "42",
+        "branch": "feature-branch-1",
     }
 
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -30,9 +30,16 @@ def test_upload_files_empty():
     assert ex.match(re.escape("No test files found"))
 
 
+NamedTemporaryFile = tempfile.NamedTemporaryFile
+
+
+def tempfile_factory():
+    return NamedTemporaryFile(delete=False)
+
+
 # Augment `NamedTemporaryFile` to not being deleted. We need it for verifying.
-@mock.patch.object(wacklig.tempfile, "NamedTemporaryFile", Mock(return_value=tempfile.NamedTemporaryFile(delete=False)))
-def test_upload_files_success(tmp_path, capsys):
+@mock.patch.object(wacklig.tempfile, "NamedTemporaryFile", tempfile_factory)
+def test_upload_files_success(capsys):
 
     # Prepare fixture data.
     wacklig_server = "https://wacklig.example.org"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 import tempfile
+from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
@@ -13,13 +14,13 @@ from wacklig import find_test_files, upload_files
 
 
 def test_find_test_files(fs):
-    fs.create_file(file_path="test-results/test/report1.xml")
-    fs.create_file(file_path="test-results/test/nested/report2.xml")
-    fs.create_file(file_path="test-results/test/nested/more/report3.xml")
+    fs.create_file(file_path=Path("test-results/test/report1.xml"))
+    fs.create_file(file_path=Path("test-results/test/nested/report2.xml"))
+    fs.create_file(file_path=Path("test-results/test/nested/more/report3.xml"))
     assert find_test_files() == [
-        "test-results/test/report1.xml",
-        "test-results/test/nested/report2.xml",
-        "test-results/test/nested/more/report3.xml",
+        str(Path("test-results/test/report1.xml")),
+        str(Path("test-results/test/nested/report2.xml")),
+        str(Path("test-results/test/nested/more/report3.xml")),
     ]
 
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,77 @@
+import io
+import os
+import re
+import tempfile
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+
+import wacklig
+from tests.conftest import here
+from wacklig import find_test_files, upload_files
+
+
+def test_find_test_files(fs):
+    fs.create_file(file_path="test-results/test/report1.xml")
+    fs.create_file(file_path="test-results/test/nested/report2.xml")
+    fs.create_file(file_path="test-results/test/nested/more/report3.xml")
+    assert find_test_files() == [
+        "test-results/test/report1.xml",
+        "test-results/test/nested/report2.xml",
+        "test-results/test/nested/more/report3.xml",
+    ]
+
+
+def test_upload_files_empty():
+    with pytest.raises(SystemExit) as ex:
+        upload_files(token=None, server=None, ci_info=None, files=None)
+    assert ex.match(re.escape("No test files found"))
+
+
+# Augment `NamedTemporaryFile` to not being deleted. We need it for verifying.
+@mock.patch.object(wacklig.tempfile, "NamedTemporaryFile", Mock(return_value=tempfile.NamedTemporaryFile(delete=False)))
+def test_upload_files_success(tmp_path, capsys):
+
+    # Prepare fixture data.
+    wacklig_server = "https://wacklig.example.org"
+    wacklig_token = "WACKLIG_TOKEN"
+    ci_info = {
+        "service": "local",
+        "branch": "testdrive",
+        "commit": "3f786850e387550fdab836ed7e6dc881de23001b",
+    }
+    test_report_files = [os.path.join(here, "tests/junit-example.xml")]
+
+    # Invoke `upload_files` with mocked `urllib.urlopen()`.
+    # TODO: Use a more realistic response payload here. Probably JSON?
+    urlopen_mock = Mock(return_value=io.BytesIO(b"HTTP response body from wacklig service"))
+    with mock.patch.object(wacklig, "urlopen", urlopen_mock):
+        upload_files(
+            token=wacklig_token,
+            server=wacklig_server,
+            ci_info=ci_info,
+            files=test_report_files,
+        )
+
+    # Proof that the request URL has correct information.
+    urlopen_mock.assert_called_once_with(
+        "https://wacklig.example.org/api/v1/upload?service=local&branch=testdrive&commit=3f786850e387550fdab836ed7e6dc881de23001b&token=WACKLIG_TOKEN",
+        data=mock.ANY,
+    )
+
+    # Proof that the HTTP request body content is a gzip payload.
+    filepath = urlopen_mock.call_args[1]["data"].name
+    assert open(filepath, "rb").read().startswith(b"\x1f\x8b\x08")
+
+    # TODO: Proof that it is actually a .tar.gz payload, having the correct content.
+
+    # Proof that the HTTP response body has been printed to stdout.
+    stdout = capsys.readouterr().out.strip()
+    assert stdout == "HTTP response body from wacklig service"
+
+    # Gracefully clean up temporary files.
+    try:
+        os.unlink(filepath)
+    except:  # pragma:nocover
+        pass

--- a/wacklig.py
+++ b/wacklig.py
@@ -37,6 +37,7 @@ def github_action_env():
         'commit': os.environ.get('GITHUB_SHA'),
         'build': os.environ.get('GITHUB_RUN_ID'),
     }
+    # Examples: refs/heads/feature-branch-1, refs/pull/42/merge
     gh_ref = os.getenv("GITHUB_REF")
     gh_head_ref = os.getenv('GITHUB_HEAD_REF')
     if gh_head_ref:
@@ -96,5 +97,5 @@ def main():
     print(f'Uploaded {len(files)} files')
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma:nocover
     main()

--- a/wacklig.py
+++ b/wacklig.py
@@ -77,9 +77,10 @@ def upload_files(token, server, ci_info, files):
         raise SystemExit('No test files found')
     ci_info['token'] = token
     with tempfile.NamedTemporaryFile() as fd:
-        with tarfile.open(fd.name, 'w:gz') as tar:
+        with tarfile.open(fileobj=fd, mode='w:gz') as tar:
             for filename in files:
                 tar.add(filename)
+        fd.seek(0)
         ci_info = {k: v for (k, v) in ci_info.items() if v}
         params = ci_info and '?' + urlencode(ci_info) or ''
         result = urlopen(server + '/api/v1/upload' + params, data=fd)

--- a/wacklig.py
+++ b/wacklig.py
@@ -45,7 +45,7 @@ def github_action_env():
         # PR ref format: refs/pull/1/merge
         data['pr'] = gh_ref.split('/')[-2]
     elif gh_ref:
-        data['branch'] = gh_ref.split("/", 3)[-1]
+        data['branch'] = gh_ref.split("/", 2)[-1]
     return data
 
 

--- a/wacklig.py
+++ b/wacklig.py
@@ -69,7 +69,7 @@ def get_ci_info():
 
 
 def find_test_files():
-    return glob('**/test-results/test/*.xml', recursive=True)
+    return glob('**/test-results/test/**/*.xml', recursive=True)
 
 
 def upload_files(token, server, ci_info, files):


### PR DESCRIPTION
Hi again,

while working on #2 and #3, I discovered that the `github_action_env` routine did not compute the `branch` attribute from the `GITHUB_REF` environment variable properly, when the effective branch name contained slashes.

661ed32d fixes it and adds another test `test_github_parse_branch_from_ref`, which exercises `GITHUB_REF` with those combinations:

- `refs/heads/feature-branch-1`
- `refs/heads/author/feature-branch-1`
- `refs/heads/realm/author/feature-branch-1`

With kind regards,
Andreas.